### PR TITLE
Support executing Unix specific launcher after update

### DIFF
--- a/ClientUpdater/Updater.cs
+++ b/ClientUpdater/Updater.cs
@@ -1387,7 +1387,7 @@ public static class Updater
                     }
                 }
 
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && downloadFile.Extension.Equals("sh", StringComparison.OrdinalIgnoreCase))
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && downloadFile.Extension.Equals(".sh", StringComparison.OrdinalIgnoreCase))
                 {
                     Logger.Log($"Updater: File {downloadFile.Name} is a script, adding execute permission.");
 

--- a/ClientUpdater/Updater.cs
+++ b/ClientUpdater/Updater.cs
@@ -25,6 +25,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Handlers;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -1384,6 +1385,21 @@ public static class Updater
 
                         return false;
                     }
+                }
+
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && downloadFile.Extension.Equals("sh", StringComparison.OrdinalIgnoreCase))
+                {
+                    Logger.Log($"Updater: File {downloadFile.Name} is a script, adding execute permission.");
+
+                    using var chmodProcess = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "/bin/sh",
+                        Arguments = $"-c 'chmod +x \"{downloadFile.FullName}\"'",
+                        CreateNoWindow = true
+                    });
+
+                    await chmodProcess.WaitForExitAsync().ConfigureAwait(false);
+                    Logger.Log($"Updater: File {downloadFile.Name} execute permission added.");
                 }
             }
 

--- a/ClientUpdater/Updater.cs
+++ b/ClientUpdater/Updater.cs
@@ -1391,10 +1391,11 @@ public static class Updater
                 {
                     Logger.Log($"Updater: File {downloadFile.Name} is a script, adding execute permission.");
 
+                    string escapedArgs = $"chmod +x {downloadFile.FullName}".Replace("\"", "\\\"");
                     using var chmodProcess = Process.Start(new ProcessStartInfo
                     {
                         FileName = "/bin/sh",
-                        Arguments = $"-c 'chmod +x \"{downloadFile.FullName}\"'",
+                        Arguments = $"-c \"{escapedArgs}\"",
                         CreateNoWindow = true
                     });
 

--- a/SecondStageUpdater/Program.cs
+++ b/SecondStageUpdater/Program.cs
@@ -151,7 +151,7 @@ internal sealed class Program
                 {
                     Write("Checking ClientDefinitions.ini for launcher executable filename.");
 
-                    string[] lines = await File.ReadAllLinesAsync(SafePath.CombineFilePath(resourceDirectory.FullName, "ClientDefinitions.ini")).ConfigureAwait(false);
+                    string[] lines = await File.ReadAllLinesAsync(SafePath.CombineFilePath(resourceDirectory.FullName, "ClientDefinitions.ini")).ConfigureAwait(true);
                     string launcherPropertyName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LauncherExe" : "UnixLauncherExe";
                     string line = lines.Single(q => q.Trim().StartsWith(launcherPropertyName, StringComparison.OrdinalIgnoreCase) && q.Contains('=', StringComparison.OrdinalIgnoreCase));
                     int commentStart = line.IndexOf(';', StringComparison.OrdinalIgnoreCase);

--- a/SecondStageUpdater/Program.cs
+++ b/SecondStageUpdater/Program.cs
@@ -21,6 +21,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Rampastring.Tools;
@@ -141,10 +142,11 @@ internal sealed class Program
 
                 try
                 {
-                    Write("Checking ClientDefinitions.ini for launcher executable filename (LauncherExe).");
+                    Write("Checking ClientDefinitions.ini for launcher executable filename.");
 
                     string[] lines = await File.ReadAllLinesAsync(SafePath.CombineFilePath(resourceDirectory.FullName, "ClientDefinitions.ini")).ConfigureAwait(false);
-                    string line = lines.Single(q => q.Trim().StartsWith("LauncherExe", StringComparison.OrdinalIgnoreCase) && q.Contains('=', StringComparison.OrdinalIgnoreCase));
+                    string launcherPropertyName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LauncherExe" : "UnixLauncherExe";
+                    string line = lines.Single(q => q.Trim().StartsWith(launcherPropertyName, StringComparison.OrdinalIgnoreCase) && q.Contains('=', StringComparison.OrdinalIgnoreCase));
                     int commentStart = line.IndexOf(';', StringComparison.OrdinalIgnoreCase);
 
                     if (commentStart >= 0)
@@ -181,7 +183,7 @@ internal sealed class Program
         }
         catch (Exception ex)
         {
-            Write("An error occured during the Launcher Updater's operation.", ConsoleColor.Red);
+            Write("An error occurred during the Launcher Updater's operation.", ConsoleColor.Red);
             Write($"Returned error was: {ex}");
             Write(string.Empty);
             Write("If you were updating a game, please try again. If the problem continues, contact the staff for support.");

--- a/SecondStageUpdater/Program.cs
+++ b/SecondStageUpdater/Program.cs
@@ -23,7 +23,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Rampastring.Tools;
 
 internal sealed class Program
@@ -34,7 +33,7 @@ internal sealed class Program
     private static bool hasHandle;
     private static Mutex clientMutex;
 
-    private static async Task Main(string[] args)
+    private static void Main(string[] args)
     {
         defaultColor = Console.ForegroundColor;
 
@@ -151,7 +150,7 @@ internal sealed class Program
                 {
                     Write("Checking ClientDefinitions.ini for launcher executable filename.");
 
-                    string[] lines = await File.ReadAllLinesAsync(SafePath.CombineFilePath(resourceDirectory.FullName, "ClientDefinitions.ini")).ConfigureAwait(true);
+                    string[] lines = File.ReadAllLines(SafePath.CombineFilePath(resourceDirectory.FullName, "ClientDefinitions.ini"));
                     string launcherPropertyName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LauncherExe" : "UnixLauncherExe";
                     string line = lines.Single(q => q.Trim().StartsWith(launcherPropertyName, StringComparison.OrdinalIgnoreCase) && q.Contains('=', StringComparison.OrdinalIgnoreCase));
                     int commentStart = line.IndexOf(';', StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
- SecondStageUpdater will launch ClientDefinitions.ini's UnixLauncherExe on a non-Windows OS.
- Updater will execute chmod +x on *nix for .sh files
- Add client mutex timeout